### PR TITLE
Refactor pre-hooks

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,8 @@
-
 name: 'snowplow_web'
 version: '0.1.0'
 config-version: 2
+
+require-dbt-version: ">=0.18.0" # TODO:Check this
 
 profile: 'default'
 
@@ -50,8 +51,12 @@ vars:
   snowplow__enable_derived_users: true
 
 
-# Commits events to event manifest if the run completes sucessfully
-on-run-start: "{{ snowplow_utils.snowplow_incremental_pre_hook('snowplow_web') }}"
+
+# on-run-start: "{{ snowplow_utils.snowplow_incremental_pre_hook('snowplow_web') }}"
+# Teardown all web manifest tables if true.
+on-run-start: "{{ snowplow_utils.snowplow_teardown_all('snowplow_web', var('snowplow_web_teardown_all', false)) }}"
+
+# Update manifest table with last event consumed per sucessfully executed node/model
 on-run-end: "{{ snowplow_utils.snowplow_incremental_post_hook('snowplow_web') }}"
 
 

--- a/docs/snowplow_web_base_docs.md
+++ b/docs/snowplow_web_base_docs.md
@@ -7,7 +7,7 @@ By knowing the lifecycle of a session the model is able to able to determine whi
 {% enddocs %}
 
 
-{% docs table_current_incremental_tstamp %}
+{% docs table_base_new_event_limits %}
 
 This table contains the lower and upper timestamp limits for the given run of the web model. These limits are used to select new events from the events table. 
 

--- a/models/base/base.yml
+++ b/models/base/base.yml
@@ -10,8 +10,8 @@ models:
         description: The `collector_tstamp` when the session began
       - name: end_tstamp
         description: The `collector_tstamp` when the session ended
-  - name: snowplow_web_current_incremental_tstamp
-    description: '{{ doc("table_current_incremental_tstamp") }}'
+  - name: snowplow_web_base_new_event_limits
+    description: '{{ doc("table_base_new_event_limits") }}'
     columns:
       - name: lower_limit
         description: The lower `collector_tstamp` limit for the run

--- a/models/base/scratch/redshift/snowplow_web_base_events_this_run.sql
+++ b/models/base/scratch/redshift/snowplow_web_base_events_this_run.sql
@@ -17,11 +17,11 @@ with sessions_this_run as (
 
   where 
      (s.end_tstamp between 
-          (select lower_limit from {{ ref('snowplow_web_current_incremental_tstamp') }})
-      and (select upper_limit from {{ ref('snowplow_web_current_incremental_tstamp') }}) )
+          (select lower_limit from {{ ref('snowplow_web_base_new_event_limits') }})
+      and (select upper_limit from {{ ref('snowplow_web_base_new_event_limits') }}) )
   or (s.start_tstamp between 
-          (select lower_limit from {{ ref('snowplow_web_current_incremental_tstamp') }})
-      and (select upper_limit from {{ ref('snowplow_web_current_incremental_tstamp') }}) )
+          (select lower_limit from {{ ref('snowplow_web_base_new_event_limits') }})
+      and (select upper_limit from {{ ref('snowplow_web_base_new_event_limits') }}) )
 )
 
 , session_limits as (

--- a/models/base/scratch/snowplow_web_base_new_event_limits.sql
+++ b/models/base/scratch/snowplow_web_base_new_event_limits.sql
@@ -1,0 +1,6 @@
+{{ config(
+	 materialized='table',
+   pre_hook=before_begin("{{ snowplow_utils.snowplow_incremental_pre_hook('snowplow_web') }}")) 
+}}
+
+select * from {{ snowplow_utils.get_current_incremental_tstamp_table_relation('snowplow_web') }}

--- a/models/base/scratch/snowplow_web_current_incremental_tstamp.sql
+++ b/models/base/scratch/snowplow_web_current_incremental_tstamp.sql
@@ -1,3 +1,0 @@
-{{ config(materialized='ephemeral') }}
-
-select * from {{ snowplow_utils.get_current_incremental_tstamp_table_relation('snowplow_web') }}

--- a/models/base/snowplow_web_base_sessions_lifecycle.sql
+++ b/models/base/snowplow_web_base_sessions_lifecycle.sql
@@ -20,8 +20,8 @@ with sessions_this_run as (
 
   where
     {{ dbt_utils.datediff('dvce_created_tstamp', 'dvce_sent_tstamp', 'day') }} <= {{ var("snowplow__days_late_allowed", 3) }} -- don't process data that's too late
-    and e.collector_tstamp >= (select lower_limit from {{ ref('snowplow_web_current_incremental_tstamp') }})
-    and e.collector_tstamp <= (select upper_limit from {{ ref('snowplow_web_current_incremental_tstamp') }})
+    and e.collector_tstamp >= (select lower_limit from {{ ref('snowplow_web_base_new_event_limits') }})
+    and e.collector_tstamp <= (select upper_limit from {{ ref('snowplow_web_base_new_event_limits') }})
     and {{ snowplow_utils.app_id_filter() }}
     and {{ has_new_events }} --don't reprocess sessions that have already been processed.
 
@@ -35,7 +35,7 @@ with sessions_this_run as (
 
   from {{ this }}
 
-  where start_tstamp >= (select {{ dbt_utils.dateadd('hour', -var("snowplow__session_lookback_days", 365), 'lower_limit') }} AS session_limit from {{ ref('snowplow_web_current_incremental_tstamp') }})
+  where start_tstamp >= (select {{ dbt_utils.dateadd('hour', -var("snowplow__session_lookback_days", 365), 'lower_limit') }} AS session_limit from {{ ref('snowplow_web_base_new_event_limits') }})
   and {{ has_new_events }} --don't reprocess sessions that have already been processed.
 )
 

--- a/models/custom_example/snowplow_web_pv_channel_engagement.sql
+++ b/models/custom_example/snowplow_web_pv_channel_engagement.sql
@@ -31,8 +31,8 @@ with link_clicks as (
   on lc.root_id = ev.event_id and lc.root_tstamp = ev.collector_tstamp
 
   where
-    lc.root_tstamp >= (select lower_limit from {{ ref('snowplow_web_current_incremental_tstamp') }})
-    and lc.root_tstamp <= (select upper_limit from {{ ref('snowplow_web_current_incremental_tstamp') }})
+    lc.root_tstamp >= (select lower_limit from {{ ref('snowplow_web_base_new_event_limits') }})
+    and lc.root_tstamp <= (select upper_limit from {{ ref('snowplow_web_base_new_event_limits') }})
 )
 
 , engagement as (


### PR DESCRIPTION
Moving calculation of run limits to a pre_hook on `snowplow_web_base_new_events_limits` rather than on-run-start. This stops the hook running when non Snowplow Web models are being executed. Better user experience and less queries